### PR TITLE
Fix device triggers when using custom MQTT topic

### DIFF
--- a/python_scripts/shellies_discovery_gen2.py
+++ b/python_scripts/shellies_discovery_gen2.py
@@ -978,7 +978,7 @@ def get_input(input_id, input_type, event):
 
     payload = {
         KEY_AUTOMATION_TYPE: VALUE_TRIGGER,
-        KEY_TOPIC: f"{device_id}/events/rpc",
+        KEY_TOPIC: f"{default_topic}events/rpc",
         KEY_PAYLOAD: f"{input_id}_{event}",
         KEY_VALUE_TEMPLATE: "{{value_json.params.events.0.id}}_{{value_json.params.events.0.event}}",
         KEY_QOS: qos,


### PR DESCRIPTION
Device triggers were using default value for MQTT topic - `device_id`. 
I've changed it to use value from configuration (`device_config['mqtt']['topic_prefix']`), same as it is for other entities.
