### PR TITLE
Ensure the configuration url uses device id

### DIFF
--- a/python_scripts/shellies_discovery_gen2.py
+++ b/python_scripts/shellies_discovery_gen2.py
@@ -1595,7 +1595,7 @@ if mac is None:
     raise ValueError("mac value None is not valid, check script configuration")
 
 device_name = device_config["sys"]["device"][ATTR_NAME]
-device_url = f"http://{device_config['mqtt']['topic_prefix']}.local/"
+device_url = f"http://{device_id}.local/"
 default_topic = f"{device_config['mqtt']['topic_prefix']}/"
 wakeup_period = device_config["sys"].get("sleep", {}).get("wakeup_period", 0)
 


### PR DESCRIPTION
Changed device url to use the device id in place of the topic prefix as the prefix is not necessarily equal to the device's hostname.

This is useful when a differing topic prefix is used. In my case, I use a topic prefix based on physical location (e.g. building/room/shellypro4pm), keeping the mqtt server organized. I have tested the change in my local install, and the configuration links work as expected within home assistant.