### PR TITLE
Correctly detect enabled slat control of 2PM Gen3

### DIFF
--- a/python_scripts/shellies_discovery_gen2.py
+++ b/python_scripts/shellies_discovery_gen2.py
@@ -3152,7 +3152,7 @@ def get_cover(cover_id, profile):
         KEY_DEFAULT_TOPIC: default_topic,
     }
 
-    if device_config[f"cover:{cover_id}"].get("slat", {}).get("enabled", False):
+    if device_config[f"cover:{cover_id}"].get("slat", {}).get("enable", False):
         payload[KEY_TILT_COMMAND_TEMPLATE] = (
             f"{{^id^:1,^src^:^{source_topic}^,^method^:^Cover.GoToPosition^,^params^:{{^id^:{cover_id},^slat_pos^:{{{{tilt_position}}}}}}}}"
         )


### PR DESCRIPTION
This PR should fix the detection of the slat feature of the 2PM Gen3. Currently it is detected as a normal cover without tilt control.

Here's the config JSON coming from the device:
```json
{
    "...other_props": "...",
    "slat": {
        "enable": true,
        "open_time": 1.8,
        "close_time": 1.8,
        "step": 20,
        "retain_pos": false,
        "precise_ctl": true
    }
}
```