### PR TITLE
Support generic BTHome devices

### DIFF
--- a/python_scripts/shellies_discovery_gen2.py
+++ b/python_scripts/shellies_discovery_gen2.py
@@ -1897,7 +1897,6 @@ SUPPORTED_MODELS = {
     },
     MODEL_GENERIC_BTHOME_DEVICE: {
         ATTR_NAME: MODEL_GENERIC_BTHOME_DEVICE,
-        ATTR_MODEL_ID: MODEL_GENERIC_BTHOME_DEVICE,
         ATTR_SENSORS: {
             SENSOR_TEMPERATURE: DESCRIPTION_SENSOR_BTH_TEMPERATURE,
             SENSOR_HUMIDITY: DESCRIPTION_SENSOR_BTH_HUMIDITY,
@@ -5568,10 +5567,11 @@ if "components" in device_config:
             KEY_IDENTIFIERS: [mac],
             KEY_NAME: device_name,
             KEY_MODEL: SUPPORTED_MODELS[model][ATTR_NAME],
-            KEY_MODEL_ID: SUPPORTED_MODELS[model][ATTR_MODEL_ID],
             KEY_MANUFACTURER: ATTR_MANUFACTURER,
             KEY_VIA_DEVICE: via_device,
         }
+        if model_id := SUPPORTED_MODELS[model].get(ATTR_MODEL_ID):
+            device_info[KEY_MODEL_ID] = model_id
 
         binary_sensors = SUPPORTED_MODELS[model].get(ATTR_BINARY_SENSORS, {})
         sensors = SUPPORTED_MODELS[model].get(ATTR_SENSORS, {})


### PR DESCRIPTION
The PR is about getting working some generic ATC BTHome thermometers (like a Xiaomi BT Home LYWSD03MMC) with ATC firmware https://github.com/pvvx/ATC_MiThermometer alongside the more expensive shelly blu HT.

I get it correctly paired with my shelly 1PM PRO (gen 2) and i see it working wiith the modifications i made.

I think this approach might not be as robust as the original one as the check is not strict on device model as these themometers doesn't publish a MODEL_ID as the shelly does.

here's some debug json from mqtt:
https://github.com/bieniu/ha-shellies-discovery-gen2/issues/691