### PR TITLE
Update label for JSON response field in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_device_support.yml
+++ b/.github/ISSUE_TEMPLATE/new_device_support.yml
@@ -60,7 +60,7 @@ body:
 
   - type: textarea
     attributes:
-      label: Shelly.GetComponents response (JSON)
+      label: Shelly.GetComponents response (JSON) *only for BLU devices
       description: Paste the full JSON response to `curl http://<DEVICE_IP>/rpc/Shelly.GetComponents?dynamic_only=true`
       placeholder: |
         {


### PR DESCRIPTION
Clarified label for Shelly.GetComponents response field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified instructions in the device support issue template to specify that the Shelly.GetComponents JSON response should only be provided for BLU devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->