### PR TITLE
Use correct ID for BT sensors

### DIFF
--- a/python_scripts/shellies_discovery_gen2.py
+++ b/python_scripts/shellies_discovery_gen2.py
@@ -5868,8 +5868,15 @@ if "components" in device_config:
                     btsensor_id = comp_id.split(":")[-1]
                     break
 
+            bt_id = (
+                btdevice_id
+                if description[KEY_STATE_TOPIC] == TOPIC_STATUS_BTH_DEVICE
+                else btsensor_id
+            )
             topic, payload = get_sensor(
-                sensor, description, bt_id=btsensor_id or btdevice_id
+                sensor,
+                description,
+                bt_id=bt_id,
             )
             config_data[topic] = payload
 
@@ -5880,8 +5887,13 @@ if "components" in device_config:
                     btsensor_id = comp_id.split(":")[-1]
                     break
 
+            bt_id = (
+                btdevice_id
+                if description[KEY_STATE_TOPIC] == TOPIC_STATUS_BTH_DEVICE
+                else btsensor_id
+            )
             topic, payload = get_binary_sensor(
-                binary_sensor, description, bt_id=btsensor_id or btdevice_id
+                binary_sensor, description, bt_id=bt_id
             )
             config_data[topic] = payload
 

--- a/python_scripts/shellies_discovery_gen2.py
+++ b/python_scripts/shellies_discovery_gen2.py
@@ -5892,9 +5892,7 @@ if "components" in device_config:
                 if description[KEY_STATE_TOPIC] == TOPIC_STATUS_BTH_DEVICE
                 else btsensor_id
             )
-            topic, payload = get_binary_sensor(
-                binary_sensor, description, bt_id=bt_id
-            )
+            topic, payload = get_binary_sensor(binary_sensor, description, bt_id=bt_id)
             config_data[topic] = payload
 
         bth_inputs = SUPPORTED_MODELS[model].get(ATTR_INPUTS, 0)

--- a/tests/snapshots/test_main.ambr
+++ b/tests/snapshots/test_main.ambr
@@ -1516,15 +1516,15 @@
       'url': 'https://github.com/bieniu/ha-shellies-discovery-gen2',
     }),
     'qos': 0,
-    'stat_t': '~status/bthomedevice:204',
-    'uniq_id': 'shellyplugusg4-aabbccddeeff-f844772233cc-204-battery',
+    'stat_t': '~status/bthomedevice:201',
+    'uniq_id': 'shellyplugusg4-aabbccddeeff-f844772233cc-201-battery',
     'unit_of_meas': '%',
     'val_tpl': '{{value_json.battery}}',
     '~': 'shellyplugusg4-aabbccddeeff/',
   })
 # ---
 # name: test_device[shelly_blu_ht_zb][3-topic]
-  'homeassistant/sensor/shellyplugusg4-aabbccddeeff-f844772233cc-204-battery/config'
+  'homeassistant/sensor/shellyplugusg4-aabbccddeeff-f844772233cc-201-battery/config'
 # ---
 # name: test_device[shelly_blu_ht_zb][4-payload]
   dict({


### PR DESCRIPTION
Closes https://github.com/bieniu/ha-shellies-discovery-gen2/issues/812

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BTHome device discovery accuracy - refined the device identifier selection logic for Home Assistant integration. The system now correctly determines which device ID to use based on the sensor's state topic, ensuring BTHome devices are accurately identified, properly grouped, and consistently synchronized in Home Assistant discovery configurations and device listings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bieniu/ha-shellies-discovery-gen2/pull/819?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->