### PR TITLE
Bugfix: Fix undefined discovery_prefix in Shellies Components Gen2 script

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ shellies_components_gen2:
         id: "{{ device_id }}"
         device_config:
           components: "{{ all_pages }}"
-        discovery_prefix: "{{ discovery_prefix }}"
+        discovery_prefix: "{{ discovery_prefix | default('homeassistant') }}"
     - variables:
         all_components: "{{ all_pages | map(attribute='components') | list | flatten }}"
     - variables:

--- a/info.md
+++ b/info.md
@@ -292,7 +292,7 @@ shellies_components_gen2:
         id: "{{ device_id }}"
         device_config:
           components: "{{ all_pages }}"
-        discovery_prefix: "{{ discovery_prefix }}"
+        discovery_prefix: "{{ discovery_prefix | default('homeassistant') }}"
     - variables:
         all_components: "{{ all_pages | map(attribute='components') | list | flatten }}"
     - variables:


### PR DESCRIPTION
### Description
Fixes a bug where virtual components are assigned an invalid topic path because the `discovery_prefix` variable drops out when the script is called by automation. 

**Error observed in logs:**
> Template variable warning: 'discovery_prefix' is undefined when rendering '{{ discovery_prefix }}'

### Solution
Added `| default('homeassistant')` to the `discovery_prefix` variable in the Shellies Components Gen2 script. This ensures the fallback is respected even when automations call the script without explicitly passing the variable.